### PR TITLE
Upgrade TF syntax to 0.12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,14 +16,15 @@ data "aws_iam_policy_document" "assume_role" {
 
 # https://www.terraform.io/docs/providers/aws/r/iam_role.html
 resource "aws_iam_role" "default" {
-  name               = "${var.role_name}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  name               = var.role_name
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
   description        = "The role to grant permissions to this account to delegated IAM users in the master account"
 }
 
 # https://www.terraform.io/docs/providers/aws/r/iam_role_policy_attachment.html
 # By default it attaches `AdministratorAccess` managed policy to grant full access to AWS services and resources in the current account
 resource "aws_iam_role_policy_attachment" "default" {
-  role       = "${aws_iam_role.default.name}"
-  policy_arn = "${var.policy_arn}"
+  role       = aws_iam_role.default.name
+  policy_arn = var.policy_arn
 }
+

--- a/output.tf
+++ b/output.tf
@@ -1,14 +1,15 @@
 output "role_name" {
-  value       = "${aws_iam_role.default.name}"
+  value       = aws_iam_role.default.name
   description = "The name of the crated role"
 }
 
 output "role_id" {
-  value       = "${aws_iam_role.default.unique_id}"
+  value       = aws_iam_role.default.unique_id
   description = "The stable and unique string identifying the role"
 }
 
 output "role_arn" {
-  value       = "${aws_iam_role.default.arn}"
+  value       = aws_iam_role.default.arn
   description = "The Amazon Resource Name (ARN) specifying the role"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,17 @@
 variable "master_account_id" {
-  type        = "string"
+  type        = string
   description = "The ID of the master account to grant permissions to access the current account"
 }
 
 variable "role_name" {
-  type        = "string"
+  type        = string
   default     = "OrganizationAccountAccessRole"
   description = "The name of the role to grant permissions to delegated IAM users in the master account to the current account"
 }
 
 variable "policy_arn" {
-  type        = "string"
+  type        = string
   default     = "arn:aws:iam::aws:policy/AdministratorAccess"
   description = "Policy ARN to attach to the role. By default it attaches `AdministratorAccess` managed policy to grant full access to AWS services and resources in the current account"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Hi,
this is a pretty stupid PR originated from a simple 'terraform 0.12upgrade'.
The syntax is now compatible con TF 0.12, anyway I've noticed that there are depencies with TF 0.11 from the build-hardness repo, so the make targets (from the terraform/install) are not compatible.
Can I do something more?
Thanks 